### PR TITLE
chore: update dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,24 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cerbos/grpc": "^0.27.0",
-        "@modelcontextprotocol/sdk": "^1.13.0",
-        "express": "^5.1.0"
+        "@cerbos/grpc": "^0.27.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "express": "^5.2.1"
       }
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
       "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cerbos/api": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.8.0.tgz",
       "integrity": "sha512-iVEdsoYax/gKchx8jv60yNv48HzXfVC/1//f6U4mo5PrGt8k28Nbb95RM4R2U7eT0p3uqDUC8PSovTIrdA6Xww==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0"
       },
@@ -602,6 +604,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -811,6 +814,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
       "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1519,6 +1523,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
       "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "type": "module",
   "description": "",
   "dependencies": {
-    "@cerbos/grpc": "^0.27.0",
-    "@modelcontextprotocol/sdk": "^1.13.0",
-    "express": "^5.1.0"
+    "@cerbos/grpc": "^0.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "express": "^5.2.1"
   }
 }


### PR DESCRIPTION
## Dependency updates

Bumps all dependencies to their latest versions via `npm-check-updates`.

| Package | Old | New |
|---|---|---|
| @cerbos/grpc | ^0.27.0 | ^0.27.1 |
| @modelcontextprotocol/sdk | ^1.13.0 | ^1.29.0 |
| express | ^5.1.0 | ^5.2.1 |

### Notable
- No major version bumps — all upgrades are minor/patch, no breaking changes expected.
- `@modelcontextprotocol/sdk` jumps 1.13 → 1.29 (minors); MCP server/transport APIs used in `index.js` (`McpServer`, `StreamableHTTPServerTransport`, `server.tool`) remain compatible.

### Verification
- No build/typecheck/test/lint scripts exist in this repo (only `start`).
- `node --check index.js` passes.
- All upgraded modules import/resolve successfully at the versions used in `index.js`.
- Full server run not exercised (requires a live Cerbos PDP on localhost:3593).